### PR TITLE
Added Squadcast notifications

### DIFF
--- a/docs/sources/alerting/notifications.md
+++ b/docs/sources/alerting/notifications.md
@@ -171,6 +171,10 @@ Once these two properties are set, you can send the alerts to Kafka for further 
 
 Notifications can be sent by setting up an incoming webhook in Google Hangouts chat. Configuring such a webhook is described [here](https://developers.google.com/hangouts/chat/how-tos/webhooks).
 
+### Squadcast
+
+Squadcast helps you get alerted via Phone call, SMS, Email and Push notifications and lets you take actions on those alerts. Grafana notifications can be sent to Squadcast via a simple incoming webhook. Refer the official [Squadcast support documentation](https://support.squadcast.com/docs/grafana) for configuring these webhooks.
+
 ### All supported notifiers
 
 Name | Type | Supports images | Support alert rule tags
@@ -189,6 +193,7 @@ Prometheus Alertmanager | `prometheus-alertmanager` | yes, external only | yes
 Pushover | `pushover` | yes | no
 Sensu | `sensu` | yes, external only | no
 Slack | `slack` | yes | no
+Squadcast | `webhook` | no | no
 Telegram | `telegram` | yes | no
 Threema | `threema` | yes, external only | no
 VictorOps | `victorops` | yes, external only | no


### PR DESCRIPTION
- Added Squadcast section 
- Added Squadcast to the **All supported notifiers** table.

**What this PR does / why we need it**:
This PR adds information about one of the notification integrations in the documentation. This will help users of Grafana and Squadcast to discover and setup the integration easily.

**Which issue(s) this PR fixes**:
NA

**Special notes for your reviewer**:
Squadcast is an on-call notification tool and many of our users suggested that these details be added to the Grafana documentation so that it will be easier for new users to discover and setup this integration.

Incase of any issues, please let us know, we will fix it and re-submit the PR again.
